### PR TITLE
Dynamically Evaluated Fines

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,23 +1,22 @@
-# Dune Details
-BILLING_QUERY=3630322
-FEE_QUERY=3605385
-PAYMENT_QUERY=3742749
-BOND_MAP="('0xa489faf6e337d997b8a23e2b6f3a8880b1b61e19', '0xfd39bc23d356a762cf80f60b7bc8d2a4b9bcfe67')"
-
 # Node Details
 ## Testnet
 RPC_URL=https://rpc.ankr.com/eth_sepolia
 BILLING_CONTRACT_ADDRESS=0xF1436859a0F04A827b79F8c92736F6331ebB64A1
-
 ## Mainnet
 # RPC_URL=https://rpc.ankr.com/eth
 # BILLING_CONTRACT_ADDRESS=0x08Cd77fEB3fB28CC1606A91E0Ea2f5e3EABa1A9a
 
+# Billing Config
+BILLING_QUERY=3630322
+FEE_QUERY=3605385
+
 # Drafting Config
 ROLE_KEY=
-FINE_FEE=0
+## This is $3.50 with ETH at $3500
+FINE_MIN=0.001
+PAYMENT_QUERY=3742749
+BOND_MAP="('0xa489faf6e337d997b8a23e2b6f3a8880b1b61e19', '0xfd39bc23d356a762cf80f60b7bc8d2a4b9bcfe67')"
 
-# Secrets
+# Secrets: Required for both Billing & Drafting
 DUNE_API_KEY=
-# Required for Billing & Drafting
 BILLER_PRIVATE_KEY=

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ yarn main drafting
 ```sh
 docker build -t mb-billing .
 ```
+
 where `PROGRAM` is one of {billing, drafting}.
 
 **Run**
@@ -54,4 +55,5 @@ docker run --rm --env-file .env mb-billing $PROGRAM
 # Published Image:
 docker run --rm --env-file .env ghcr.io/cowanator/mb-billing:main $PROGRAM
 ```
+
 where `PROGRAM` is one of {billing, drafting}.

--- a/README.md
+++ b/README.md
@@ -26,31 +26,32 @@ yarn
 cp .env.sample .env
 ```
 
-Some values are filled, but others require secrets (`DUNE_API_KEY`, `BILLER_PRIVATE_KEY` for billing and `OWNER_PRIVATE_KEY` for drafting).
+Some values are filled, but others require secrets (`DUNE_API_KEY`, `BILLER_PRIVATE_KEY` for billing and `ROLE_KEY` for drafting).
 
 Run the Script:
 
 ```sh
 # Billing: Requires `BILLER_PRIVATE_KEY`
 yarn main billing
-# Drafting: Requires `OWNER_PRIVATE_KEY`
+# Drafting: Requires `BILLER_PRIVATE_KEY` & `ROLE_KEY`
 yarn main drafting
 ```
 
 ## Docker
 
-**Local build and run**
+**Build**
 
 ```sh
 docker build -t mb-billing .
-docker run --rm --env-file .env mb-billing $PROGRAM
 ```
-
 where `PROGRAM` is one of {billing, drafting}.
 
-**Published image**
+**Run**
 
 ```sh
-export PROGRAM={billing, drafting}
+# Local:
+docker run --rm --env-file .env mb-billing $PROGRAM
+# Published Image:
 docker run --rm --env-file .env ghcr.io/cowanator/mb-billing:main $PROGRAM
 ```
+where `PROGRAM` is one of {billing, drafting}.

--- a/src/gas.ts
+++ b/src/gas.ts
@@ -1,0 +1,36 @@
+import { ethers } from "ethers";
+
+export async function getTxCostForGas(
+  provider: ethers.JsonRpcProvider,
+  gasEstimate: bigint,
+): Promise<bigint> {
+  const [{ maxPriorityFeePerGas, maxFeePerGas }, latestBlock] =
+    await Promise.all([provider.getFeeData(), provider.getBlock("latest")]);
+  if (!maxPriorityFeePerGas || !maxFeePerGas) {
+    throw new Error("no gas fee data");
+  }
+  const baseFeePerGas = latestBlock!.baseFeePerGas;
+  if (!baseFeePerGas) {
+    throw new Error("No base fee data");
+  }
+  const effectiveGasPrice = minBigInt(
+    baseFeePerGas + maxPriorityFeePerGas,
+    maxFeePerGas,
+  );
+
+  return gasEstimate * effectiveGasPrice;
+}
+
+export function minBigInt(a: bigint, b: bigint): bigint {
+  if (a < b) {
+    return a;
+  }
+  return b;
+}
+
+export function maxBigInt(a: bigint, b: bigint): bigint {
+  if (a > b) {
+    return a;
+  }
+  return b;
+}

--- a/tests/e2e/e2e.test.ts
+++ b/tests/e2e/e2e.test.ts
@@ -43,10 +43,9 @@ describe("e2e - Sepolia", () => {
     const draftHash =
       await billingContract.processPaymentStatuses(paymentStatus);
     // This is a non-deterministic test.
-    console.log("Drafting Hashes", draftHash);
-
+    console.log("Drafting Hashe", draftHash);
     const provider = billingContract.contract.runner!.provider;
-    const receipt = await provider!.getTransactionReceipt(draftHash);
+    const receipt = await provider!.getTransactionReceipt(draftHash!);
     // 2 drafts + 2 fines + 2 safe module transactions.
     const expectedLogs = 1 + 2 + 2 + 1;
     expect(receipt?.logs!.length).toEqual(expectedLogs);


### PR DESCRIPTION
This PR introduces a more sophisticated Fine Mechanism: 

The bundle of `drafts` is constructed as a multisend then a gas estimation is evaluated. Then the total transaction cost is estimated as 

```
txCost = gasEstimation * min(baseFeePerGas + maxPriorityFeePerGas, maxFeePerGas)
```

The fine amount is then 

```
max((txCost * 2) / drafts.length, MIN_FINE);
```
where `txCost * 2` represents the estimation of the bundle of both (drafts & fines), division by the number of drafts distributed the fine equally among the accounts being drafted.

So this `fineAmount` says, the fine is `MIN_FINE` unless the transaction cost for execution winds up being more.

**Possible Alternatives:**

1. Evaluate `gasEstimate` for singular drafts, sum them all up, do the same as above with the sum and then execute as a batch anyway. This is kinda like skimming - so not implemented.
2. Build the Full Transaction (with some fixed fine), perform a more accurate gas estimation, then go back an replace all the fine transactions with the newly computed fineAmount. Seems kinda ugly to rebuild the fines.


## Testing

There is an e2e test demonstrating the full flow.
We could add a few unit tests to the newly introduced functions (`getTxCostForGas`, `minBigInt`, `maxBigInt`, and `evaluateFine`).
